### PR TITLE
fip-002

### DIFF
--- a/FIPs/fip-002.md
+++ b/FIPs/fip-002.md
@@ -1,0 +1,27 @@
+---
+fip: 002
+title: Raise max_gas setting and max bytes per block
+author: Fetch Foundation (developer@fetch.ai)
+description: Raise max_gas setting to 3M FET from 2M FET and increase the max bytes per block from 200KB to 300KB.
+discussions-to: 
+status: Draft
+type: Ecosystem
+created: 2022-07-19
+requires:
+Withdrawal-reason:
+---
+## Abstract
+
+Raise max_gas setting to 3M FET from 2M FET and increase the max bytes per block from 200KB to 300KB
+
+## Motivation
+
+Currently the max_gas and max bytes per block on the mainnet are not in alignmnent with those on the testnet. 
+
+## Specification
+
+The max_gas setting is being raised to 3M FET from 2M FET and we are also increasing the max bytes per block in order to allow bigger and more complex smart contracts to be deployed on the network. These on-chain parameter changes are also being implemented to align with the actual testnet configuration. 
+
+## Rationale
+
+Fetch-ai Network supports Cosmwasm based smart contracts that can support complex business logic. Such complex smart contracts require a higher gas limit for deploying them and a higher byte limit for storing them. Fetch-ai Network ecosystem has new DApps that are using complex smart contracts and will need these higher limits to launch. The values proposed in this FIP for the max_gas and max bytes have proven to be appropriate for the complex smart contracts on the testnet where such DApps have been successfully testing. Therefore, these parameter changes now need to be applied on the Mainnet.

--- a/FIPs/fip-002.md
+++ b/FIPs/fip-002.md
@@ -4,7 +4,7 @@ title: Raise max_gas setting and max bytes per block
 author: Fetch Foundation (developer@fetch.ai)
 description: Raise max_gas setting to 3M FET from 2M FET and increase the max bytes per block from 200KB to 300KB.
 discussions-to: 
-status: in-review
+status: Voting
 type: Ecosystem
 created: 2022-07-19
 requires:

--- a/FIPs/fip-002.md
+++ b/FIPs/fip-002.md
@@ -4,11 +4,14 @@ title: Raise max_gas setting and max bytes per block
 author: Fetch Foundation (developer@fetch.ai)
 description: Raise max_gas setting to 3M FET from 2M FET and increase the max bytes per block from 200KB to 300KB.
 discussions-to: 
-status: Draft
+status: in-review
 type: Ecosystem
 created: 2022-07-19
 requires:
 Withdrawal-reason:
+review-deadline: 2022-07-22
+last-call: 2022-07-21
+author-response-wait-time: 1 hour
 ---
 ## Abstract
 

--- a/FIPs/fip-002.md
+++ b/FIPs/fip-002.md
@@ -4,7 +4,7 @@ title: Raise max_gas setting and max bytes per block
 author: Fetch Foundation (developer@fetch.ai)
 description: Raise max_gas setting to 3M FET from 2M FET and increase the max bytes per block from 200KB to 300KB.
 discussions-to: 
-status: Voting
+status: Accepted
 type: Ecosystem
 created: 2022-07-19
 requires:


### PR DESCRIPTION
`fip`: 002
`title`: Raise max_gas setting and max bytes per block
`author`: Fetch Foundation (developer@fetch.ai)
`description`: Raise max_gas setting to 3M from 2M and increase the max bytes per block from 200KB to 300KB.
`discussions-to`: 
`status`: Accepted
`type`: Ecosystem
`created`: 2022-07-19
`requires`:
`Withdrawal-reason`:
`review-deadline`: 2022-07-22
`last-call`: 2022-07-21
`author-response-wait-time`: 1 hour